### PR TITLE
Memory leak and minor changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.9-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!--Bukkit API-->
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.9-R0.1-SNAPSHOT</version>
+            <version>1.14-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.anjocaido.groupmanager</groupId>
     <artifactId>GroupManagerRevived</artifactId>
-    <version>2.13-SNAPSHOT</version>
+    <version>2.14-SNAPSHOT</version>
     
     <packaging>jar</packaging>
     

--- a/src/main/java/org/anjocaido/groupmanager/GroupManager.java
+++ b/src/main/java/org/anjocaido/groupmanager/GroupManager.java
@@ -1265,7 +1265,7 @@ public class GroupManager extends JavaPlugin {
                     }
                     // Seems OK
                     auxGroup.addInherits(auxGroup2);
-                    sender.sendMessage(ChatColor.RED + "Group " + auxGroup2.getName() + " is now in " + auxGroup.getName() + " inheritance list.");
+                    sender.sendMessage(ChatColor.YELLOW + "Group " + auxGroup2.getName() + " is now in " + auxGroup.getName() + " inheritance list.");
 
                     BukkitPermissions.updateAllPlayers();
 
@@ -1300,16 +1300,16 @@ public class GroupManager extends JavaPlugin {
 
                     // Validating permission
                     if (!permissionHandler.hasGroupInInheritance(auxGroup, auxGroup2.getName())) {
-                        sender.sendMessage(ChatColor.RED + "Group " + auxGroup.getName() + " does not inherits " + auxGroup2.getName() + ".");
+                    	sender.sendMessage(ChatColor.RED + "Group " + auxGroup.getName() + " does not inherit " + auxGroup2.getName() + ".");
                         return true;
                     }
                     if (!auxGroup.getInherits().contains(auxGroup2.getName())) {
-                        sender.sendMessage(ChatColor.RED + "Group " + auxGroup.getName() + " does not inherits " + auxGroup2.getName() + " directly.");
+                    	sender.sendMessage(ChatColor.RED + "Group " + auxGroup.getName() + " does not inherit " + auxGroup2.getName() + " directly.");
                         return true;
                     }
                     // Seems OK
                     auxGroup.removeInherits(auxGroup2.getName());
-                    sender.sendMessage(ChatColor.RED + "Group " + auxGroup2.getName() + " was removed from " + auxGroup.getName() + " inheritance list.");
+                    sender.sendMessage(ChatColor.YELLOW + "Group " + auxGroup2.getName() + " was removed from " + auxGroup.getName() + " inheritance list.");
 
                     BukkitPermissions.updateAllPlayers();
 

--- a/src/main/java/org/anjocaido/groupmanager/permissions/BukkitPermissions.java
+++ b/src/main/java/org/anjocaido/groupmanager/permissions/BukkitPermissions.java
@@ -444,6 +444,12 @@ public class BukkitPermissions {
             }
 
             Player player = event.getPlayer();
+			String uuid = player.getUniqueId().toString();
+
+			// Reset the User objects player reference.
+			User user = plugin.getWorldsHolder().getWorldData(player.getWorld().getName()).getUser(uuid, player.getName());
+
+			user.updatePlayer(null);
 
             /*
              * force remove any attachments as bukkit may not

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: GroupManager
-version: 2.13-SNAPSHOT
+version: 2.14-SNAPSHOT
 main: org.anjocaido.groupmanager.GroupManager
 website: https://github.com/Sycholic/GroupManagerRevived
 description: Provides on-the-fly system for permissions system created by Nijikokun. But all in memory, and with flat-file saving schedule.


### PR DESCRIPTION
You probably don't care to update this anymore since it's so old but i'm doing a PR anyway just in case.
I was using this plugin for a long time and only now noticed it was keeping references to Player objects. It seems like it was forked from the wrong Essentials branch since they had it already fixed on their groupmanager branch.